### PR TITLE
Switch to xml report format for jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,8 @@
         </ditto.thirdPartyLicences.excludedGroups>
 
         <japicmp-maven-plugin.version>0.14.3</japicmp-maven-plugin.version>
+      
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>
@@ -389,7 +391,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.3</version>
+                    <version>0.8.5</version>
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>
@@ -627,7 +629,7 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
                       <execution>
-                            <id>prepare</id>
+                            <id>prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
                             </goals>
@@ -635,7 +637,7 @@
                         <execution>
                             <id>report</id>
                             <goals>
-                                <goal>report-aggregate</goal>
+                                <goal>report</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
JaCoCo: Switch from binary (deprecated) to xml report format.